### PR TITLE
Parent directories displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ fichier
 
 ### Exécution
 
-Lancez la commande depuis de dossier parent du dépôt. Exemple:
+Lancez la commande depuis de dossier **parent** du dépôt. Exemple:
 
 ```
 python last-file-modif -d last-file-modif
@@ -24,6 +24,11 @@ Exemple:
 
 ```
 python __main__.py -d .
+```
+
+Afficher l'aide:
+```
+python last-file-modif -h
 ```
 
 ## ENGLISH
@@ -39,7 +44,7 @@ names
 
 ### Execution
 
-Run the command from the repository's parent directory. Example:
+Run the command from the repository's **parent** directory. Example:
 
 ```
 python last-file-modif -d last-file-modif
@@ -50,4 +55,9 @@ Example:
 
 ```
 python __main__.py -d .
+```
+
+Display the help:
+```
+python last-file-modif -h
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@
 Cette application en ligne de commande affiche le nom et le moment de la
 dernière modification de chaque élément du dossier spécifié.
 
-## Exécution
+### Arguments
+
+* `-d`/`--directory`: le chemin d'un dossier
+* `-p`/`--parents`: le nombre de dossiers parents à afficher avant les noms de
+fichier
+
+### Exécution
 
 Lancez la commande depuis de dossier parent du dépôt. Exemple:
 
@@ -25,7 +31,13 @@ python __main__.py -d .
 This command line application displays the name and the moment of the last
 modification of each item in the specified directory.
 
-## Execution
+### Arguments
+
+* `-d`/`--directory`: the path to a directory
+* `-p`/`--parents`: the number of parent directories to display before the file
+names
+
+### Execution
 
 Run the command from the repository's parent directory. Example:
 

--- a/__main__.py
+++ b/__main__.py
@@ -9,7 +9,7 @@ def _make_arg_parser():
 	parser.add_argument("-d", "--directory", type=Path, required=True,
 		help="The path to a directory")
 	parser.add_argument("-p", "--parents", type=int, required=False, default=0,
-		help="The number of parent directories to display with the file names")
+		help="The number of parent directories to display before the file names")
 	return parser
 
 

--- a/__main__.py
+++ b/__main__.py
@@ -1,3 +1,8 @@
+"""
+This command line application displays the name and the moment of the last
+modification of each item in the specified directory.
+"""
+
 from datetime import datetime
 from pathlib import Path
 from argparse import ArgumentParser
@@ -5,7 +10,7 @@ from sys import exit
 
 
 def _make_arg_parser():
-	parser = ArgumentParser()
+	parser = ArgumentParser(description=__doc__)
 	parser.add_argument("-d", "--directory", type=Path, required=True,
 		help="The path to a directory")
 	parser.add_argument("-p", "--parents", type=int, required=False, default=0,

--- a/__main__.py
+++ b/__main__.py
@@ -11,6 +11,14 @@ def _make_arg_parser():
 	return parser
 
 
+def _rel_path_with_nb_parents(some_path, nb_parents):
+	if nb_parents >= 1:
+		some_path = some_path.resolve()
+		return some_path.relative_to(some_path.parents[nb_parents])
+	else:
+		return some_path.name
+
+
 arg_parser = _make_arg_parser()
 args = arg_parser.parse_args()
 directory = args.directory
@@ -23,4 +31,6 @@ for item in directory.glob("*"):
 	last_modif_timestamp = item.stat().st_mtime
 	last_modif_moment = datetime.fromtimestamp(last_modif_timestamp)
 	last_modif_strf = last_modif_moment.isoformat()
-	print(f"{item.name}....{last_modif_strf}")
+
+	item = _rel_path_with_nb_parents(item, 2)
+	print(f"{item}....{last_modif_strf}")

--- a/__main__.py
+++ b/__main__.py
@@ -16,7 +16,14 @@ def _make_arg_parser():
 def _rel_path_with_nb_parents(some_path, nb_parents):
 	if nb_parents >= 1:
 		some_path = some_path.resolve()
-		return some_path.relative_to(some_path.parents[nb_parents])
+		some_path_parents = some_path.parents
+
+		max_nb_parents = len(some_path_parents)
+		if nb_parents >= max_nb_parents:
+			nb_parents = max_nb_parents - 1
+
+		return some_path.relative_to(some_path_parents[nb_parents])
+
 	else:
 		return some_path.name
 

--- a/__main__.py
+++ b/__main__.py
@@ -19,18 +19,16 @@ def _make_arg_parser():
 
 
 def _rel_path_with_nb_parents(some_path, nb_parents):
-	if nb_parents >= 1:
-		some_path = some_path.resolve()
-		some_path_parents = some_path.parents
+	if nb_parents <= 0:
+		return some_path.name
 
-		max_nb_parents = len(some_path_parents)
-		if nb_parents >= max_nb_parents:
-			nb_parents = max_nb_parents - 1
+	some_path = some_path.resolve()
+	some_path_parents = some_path.parents
 
+	if nb_parents < len(some_path_parents):
 		return some_path.relative_to(some_path_parents[nb_parents])
 
-	else:
-		return some_path.name
+	return some_path
 
 
 arg_parser = _make_arg_parser()

--- a/__main__.py
+++ b/__main__.py
@@ -8,6 +8,8 @@ def _make_arg_parser():
 	parser = ArgumentParser()
 	parser.add_argument("-d", "--directory", type=Path, required=True,
 		help="The path to a directory")
+	parser.add_argument("-p", "--parents", type=int, required=False, default=0,
+		help="The number of parent directories to display with the file names")
 	return parser
 
 
@@ -22,6 +24,7 @@ def _rel_path_with_nb_parents(some_path, nb_parents):
 arg_parser = _make_arg_parser()
 args = arg_parser.parse_args()
 directory = args.directory
+nb_parents = args.parents
 
 if not directory.is_dir():
 	print("-d/--direcotry: A direcotry is expected.")
@@ -32,5 +35,5 @@ for item in directory.glob("*"):
 	last_modif_moment = datetime.fromtimestamp(last_modif_timestamp)
 	last_modif_strf = last_modif_moment.isoformat()
 
-	item = _rel_path_with_nb_parents(item, 2)
+	item = _rel_path_with_nb_parents(item, nb_parents)
 	print(f"{item}....{last_modif_strf}")


### PR DESCRIPTION
* Argument `-p`/`--parents` specificies the number of parent directories before the file names.
* `README` presents the command line arguments.
* The command line help includes the application's description.